### PR TITLE
Added strict typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All Notable changes to `digipolisgent/api-client` package.
 * Renamed the AbstractRequest class to AbstractJsonRequest.
 * The client in ServiceAbstract is now only accessible in extending
   classes trough protected method ServiceAbstract::client().
-  
+
 ### Removed
 
 * Removed chaining ClientInterface::addHandler() method calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All Notable changes to `digipolisgent/api-client` package.
 
+## [Unreleased]
+
+### Added
+
+* Added AbstractXmlRequest class.
+
+### Changed
+
+* Made the code strict.
+* Renamed the AbstractRequest class to AbstractJsonRequest.
+* The client in ServiceAbstract is now only accessible in extending
+  classes trough protected method ServiceAbstract::client().
+  
+### Removed
+
+* Removed chaining ClientInterface::addHandler() method calls.
+
 ## [1.2.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     ],
     "require": {
         "php": ">=7.2",
+        "ext-json": "*",
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^6.0",
         "psr/simple-cache": "^1.0"

--- a/src/Cache/CacheableInterface.php
+++ b/src/Cache/CacheableInterface.php
@@ -1,20 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
 /**
- * Interface LoggableInterface.
- *
- * @package DigipolisGent\API\Logger
+ * Interface to add cache to a service.
  */
 interface CacheableInterface
 {
     /**
      * Set the cache service.
      *
-     * @param CacheInterface $cache
+     * @param \Psr\SimpleCache\CacheInterface $cache
      */
-    public function setCacheService(CacheInterface $cache);
+    public function setCacheService(CacheInterface $cache): void;
 }

--- a/src/Cache/CacheableTrait.php
+++ b/src/Cache/CacheableTrait.php
@@ -47,11 +47,10 @@ trait CacheableTrait
      *   Item is cached.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   If the $key string is not a legal value.
      */
     protected function cacheSet(string $key, $value, $ttl = null): bool
     {
-        if (!$this->cache) {
+        if ($this->cache === null) {
             return false;
         }
 
@@ -71,11 +70,10 @@ trait CacheableTrait
      *   Item is deleted.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   If the $key string is not a legal value.
      */
     protected function cacheDelete(string $key): bool
     {
-        if (!$this->cache) {
+        if ($this->cache === null) {
             return false;
         }
 
@@ -90,7 +88,7 @@ trait CacheableTrait
      */
     protected function cacheClear(): bool
     {
-        if (!$this->cache) {
+        if ($this->cache === null) {
             return false;
         }
 
@@ -112,11 +110,10 @@ trait CacheableTrait
      *   Cached value or default if no cache for the item.
      *
      * @throws \Psr\SimpleCache\InvalidArgumentException
-     *   If the $key string is not a legal value.
      */
     protected function cacheGet(string $key, $default = null)
     {
-        if (!$this->cache) {
+        if ($this->cache === null) {
             return null;
         }
 

--- a/src/Cache/CacheableTrait.php
+++ b/src/Cache/CacheableTrait.php
@@ -1,31 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Cache;
 
 use Psr\SimpleCache\CacheInterface;
 
 /**
- * Class LoggableTrait.
- *
- * Use this trait to add cache to an object.
- *
- * @package DigipolisGent\API\Cache
+ * Use this trait to add cache support to an object.
  */
 trait CacheableTrait
 {
     /**
      * The cache service.
      *
-     * @var CacheInterface
+     * @var \Psr\SimpleCache\CacheInterface
      */
     protected $cache;
 
     /**
      * Set the cache service.
      *
-     * @param CacheInterface $cache
+     * @param \Psr\SimpleCache\CacheInterface $cache
      */
-    public function setCacheService(CacheInterface $cache)
+    public function setCacheService(CacheInterface $cache): void
     {
         $this->cache = $cache;
     }
@@ -51,7 +49,7 @@ trait CacheableTrait
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   If the $key string is not a legal value.
      */
-    protected function cacheSet($key, $value, $ttl = null)
+    protected function cacheSet(string $key, $value, $ttl = null): bool
     {
         if (!$this->cache) {
             return false;
@@ -75,7 +73,7 @@ trait CacheableTrait
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   If the $key string is not a legal value.
      */
-    protected function cacheDelete($key)
+    protected function cacheDelete(string $key): bool
     {
         if (!$this->cache) {
             return false;
@@ -90,7 +88,7 @@ trait CacheableTrait
      * @return bool
      *   Cache is cleared.
      */
-    protected function cacheClear()
+    protected function cacheClear(): bool
     {
         if (!$this->cache) {
             return false;
@@ -116,7 +114,7 @@ trait CacheableTrait
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   If the $key string is not a legal value.
      */
-    protected function cacheGet($key, $default = null)
+    protected function cacheGet(string $key, $default = null)
     {
         if (!$this->cache) {
             return null;

--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -1,66 +1,78 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client;
 
 use DigipolisGent\API\Client\Configuration\ConfigurationInterface;
 use DigipolisGent\API\Client\Exception\HandlerNotFound;
+use DigipolisGent\API\Client\Handler\HandlerInterface;
+use DigipolisGent\API\Client\Response\ResponseInterface;
 use DigipolisGent\API\Logger\LoggableInterface;
 use DigipolisGent\API\Logger\LoggableTrait;
 use DigipolisGent\API\Logger\RequestLog;
 use DigipolisGent\API\Logger\ResponseLog;
+use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Class ClientAbstract.
- *
- * @package DigipolisGent\API\Client
+ * Abstract implementation of the service client.
  */
 abstract class AbstractClient implements ClientInterface, LoggableInterface
 {
     use LoggableTrait;
 
     /**
-     * @var Handler\HandlerInterface[]
+     * Handlers this client has to handle the requests.
+     *
+     * @var \DigipolisGent\API\Client\Handler\HandlerInterface[]
      */
     protected $handlers = [];
 
     /**
+     * Guzzle HTTP client.
+     *
      * @var \GuzzleHttp\Client
      */
     protected $guzzle;
 
     /**
-     * @var ConfigurationInterface
+     * The client configuration.
+     *
+     * @var \DigipolisGent\API\Client\Configuration\ConfigurationInterface
      */
     protected $configuration;
 
     /**
      * Client constructor.
      *
-     * @param \GuzzleHttp\Client $guzzle
-     * @param ConfigurationInterface $configuration
+     * @param \GuzzleHttp\ClientInterface $guzzle
+     * @param \DigipolisGent\API\Client\Configuration\ConfigurationInterface $configuration
      */
-    public function __construct(\GuzzleHttp\Client $guzzle, ConfigurationInterface $configuration)
+    public function __construct(GuzzleClientInterface $guzzle, ConfigurationInterface $configuration)
     {
-        $this->guzzle        = $guzzle;
+        $this->guzzle = $guzzle;
         $this->configuration = $configuration;
     }
 
     /**
-     * Sends a Request and returns the appropriate Response
+     * Sends a Request and returns the appropriate Response.
      *
-     * @param RequestInterface $request
-     * @return Response\ResponseInterface
-     * @throws HandlerNotFound
+     * @param \Psr\Http\Message\RequestInterface $request
+     *
+     * @return \DigipolisGent\API\Client\Response\ResponseInterface
+     *
+     * @throws \DigipolisGent\API\Client\Exception\HandlerNotFound
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function send(RequestInterface $request)
+    public function send(RequestInterface $request): ResponseInterface
     {
         $psrRequest  = $this->injectHeaders($request);
 
         $this->log(new RequestLog($request));
 
-        $handler     = $this->getHandler($request);
+        $handler = $this->getHandler($request);
         try {
             $psrResponse = $this->guzzle->send($psrRequest);
         } catch (ClientException $e) {
@@ -75,24 +87,27 @@ abstract class AbstractClient implements ClientInterface, LoggableInterface
     /**
      * Adds headers to a Request object
      *
-     * @param RequestInterface $request
-     * @return RequestInterface
+     * @param \Psr\Http\Message\RequestInterface $request
+     *
+     * @return \Psr\Http\Message\RequestInterface
      */
-    protected function injectHeaders(RequestInterface $request)
+    protected function injectHeaders(RequestInterface $request): RequestInterface
     {
         return $request
-            ->withHeader('Content-Length', strlen((string)$request->getBody()))
+            ->withHeader('Content-Length', strlen((string) $request->getBody()))
         ;
     }
 
     /**
      * Returns the correct handler for the given Request-object
      *
-     * @param RequestInterface $request
-     * @return Handler\HandlerInterface
-     * @throws HandlerNotFound
+     * @param \Psr\Http\Message\RequestInterface $request
+     *
+     * @return \DigipolisGent\API\Client\Handler\HandlerInterface
+     *
+     * @throws \DigipolisGent\API\Client\Exception\HandlerNotFound
      */
-    protected function getHandler(RequestInterface $request)
+    protected function getHandler(RequestInterface $request): HandlerInterface
     {
         if (array_key_exists(get_class($request), $this->handlers)) {
             return $this->handlers[get_class($request)];
@@ -102,17 +117,15 @@ abstract class AbstractClient implements ClientInterface, LoggableInterface
     }
 
     /**
-     * Registers one handler
+     * Registers a single handler.
      *
-     * @param Handler\HandlerInterface $handler
-     * @return $this
+     * @param \DigipolisGent\API\Client\Handler\HandlerInterface $handler
      */
-    public function addHandler(Handler\HandlerInterface $handler)
+    public function addHandler(HandlerInterface $handler): void
     {
         $requestTypes = (array) $handler->handles();
         foreach ($requestTypes as $requestType) {
             $this->handlers[$requestType] = $handler;
         }
-        return $this;
     }
 }

--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -11,7 +11,6 @@ use DigipolisGent\API\Client\Response\ResponseInterface;
 use DigipolisGent\API\Logger\LoggableInterface;
 use DigipolisGent\API\Logger\LoggableTrait;
 use DigipolisGent\API\Logger\RequestLog;
-use DigipolisGent\API\Logger\ResponseLog;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
@@ -33,7 +32,7 @@ abstract class AbstractClient implements ClientInterface, LoggableInterface
     /**
      * Guzzle HTTP client.
      *
-     * @var \GuzzleHttp\Client
+     * @var \GuzzleHttp\ClientInterface
      */
     protected $guzzle;
 
@@ -79,8 +78,6 @@ abstract class AbstractClient implements ClientInterface, LoggableInterface
             $psrResponse = $e->getResponse();
         }
 
-        $this->log(new ResponseLog($psrResponse));
-
         return $handler->toResponse($psrResponse);
     }
 
@@ -93,9 +90,10 @@ abstract class AbstractClient implements ClientInterface, LoggableInterface
      */
     protected function injectHeaders(RequestInterface $request): RequestInterface
     {
-        return $request
-            ->withHeader('Content-Length', strlen((string) $request->getBody()))
-        ;
+        return $request->withHeader(
+            'Content-Length',
+            (string) strlen((string) $request->getBody())
+        );
     }
 
     /**

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -10,8 +10,6 @@ use Psr\Http\Message\RequestInterface;
  * Client Interface.
  *
  * This is a wrapper around the actual used HTTP request (Guzzle, Drupal, …).
- *
- * @package DigipolisGent\API\Client
  */
 interface ClientInterface
 {

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -18,19 +18,18 @@ interface ClientInterface
     /**
      * Perform a request to the Gent Services backend.
      *
-     * @param RequestInterface $request
-     *   The request parameters.
+     * @param \Psr\Http\Message\RequestInterface $request
+     *   The request to be send.
      *
-     * @return ResponseInterface
+     * @return \DigipolisGent\API\Client\Response\ResponseInterface
      *   The response of the service call.
      */
-    public function send(RequestInterface $request);
+    public function send(RequestInterface $request): ResponseInterface;
 
     /**
      * Adds a Handler to the Client
      *
-     * @param HandlerInterface $handler
-     * @return ClientInterface
+     * @param \DigipolisGent\API\Client\Handler\HandlerInterface $handler
      */
-    public function addHandler(HandlerInterface $handler);
+    public function addHandler(HandlerInterface $handler): void;
 }

--- a/src/Client/Configuration/Configuration.php
+++ b/src/Client/Configuration/Configuration.php
@@ -1,7 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Configuration;
 
+/**
+ * Configuration used to create the client.
+ */
 class Configuration implements ConfigurationInterface
 {
     /**
@@ -16,10 +21,10 @@ class Configuration implements ConfigurationInterface
      *
      * @var array
      */
-    protected $options = array(
+    protected $options = [
         'version' => 1,
         'timeout' => 20,
-    );
+    ];
 
     /**
      * @inheritDoc
@@ -40,7 +45,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @inheritDoc
      */
-    public function getUri()
+    public function getUri(): string
     {
         return $this->endpointUri;
     }
@@ -48,15 +53,15 @@ class Configuration implements ConfigurationInterface
     /**
      * @inheritDoc
      */
-    public function getVersion()
+    public function getVersion(): string
     {
-        return $this->options['version'];
+        return (string) $this->options['version'];
     }
 
     /**
      * @inheritDoc
      */
-    public function getTimeout()
+    public function getTimeout(): int
     {
         return $this->options['timeout'];
     }

--- a/src/Client/Configuration/Configuration.php
+++ b/src/Client/Configuration/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @inheritDoc
      */
-    public function __construct($endpointUri, array $options = array())
+    public function __construct($endpointUri, array $options = [])
     {
         $this->endpointUri = $endpointUri;
 

--- a/src/Client/Configuration/ConfigurationInterface.php
+++ b/src/Client/Configuration/ConfigurationInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Configuration;
 
 /**
- * Interface ConfigurationInterface.
- *
- * @package DigipolisGent\API\Client\Configuration
+ * Configuration used to create the client.
  */
 interface ConfigurationInterface
 {
@@ -14,19 +14,19 @@ interface ConfigurationInterface
      *
      * @return string
      */
-    public function getUri();
+    public function getUri(): string;
 
     /**
      * Get the service version number to use.
      *
      * @return string
      */
-    public function getVersion();
+    public function getVersion(): string;
 
     /**
      * Get the timeout value.
      *
      * @return int
      */
-    public function getTimeout();
+    public function getTimeout(): int;
 }

--- a/src/Client/Exception/Exception.php
+++ b/src/Client/Exception/Exception.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
+
+use Exception as PhpException;
 
 /**
  * Client Exception.
- *
- * @package DigipolisGent\API\Client\Exception
  */
-class Exception extends \Exception
+class Exception extends PhpException
 {
 
 }

--- a/src/Client/Exception/Handler.php
+++ b/src/Client/Exception/Handler.php
@@ -1,8 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
 
+/**
+ * Handler exception.
+ */
 class Handler extends Exception
 {
-    
+
 }

--- a/src/Client/Exception/HandlerNotFound.php
+++ b/src/Client/Exception/HandlerNotFound.php
@@ -1,21 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
 
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Class HandlerNotFound
- *
- * @package DigipolisGent\API\Client\Exception
+ * Exception thrown when no handler is found for the given request.
  */
 class HandlerNotFound extends Handler
 {
     /**
      * @param RequestInterface $request
-     * @return HandlerNotFound
+     *
+     * @return \DigipolisGent\API\Client\Exception\HandlerNotFound
      */
-    public static function fromRequest(RequestInterface $request)
+    public static function fromRequest(RequestInterface $request): HandlerNotFound
     {
         return new self(sprintf('No handler was registered for %s', get_class($request)));
     }

--- a/src/Client/Exception/InvalidResponse.php
+++ b/src/Client/Exception/InvalidResponse.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
 
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Class InvalidResponse
- *
- * @package DigipolisGent\API\Client\Exception
+ * Exception thrown when the response has invalid data.
  */
 class InvalidResponse extends Exception
 {
@@ -21,28 +21,30 @@ class InvalidResponse extends Exception
      *
      * @param string $message
      * @param array $data
+     * @param int $code
      */
-    public function __construct($message, array $data = [], $code = 0)
+    public function __construct(string $message, array $data = [], $code = 0)
     {
         $this->data = $data;
         parent::__construct($message, $code);
     }
 
     /**
-     * Generates an Exception with a uniform message
+     * Generates an Exception with a uniform message from a given request.
      *
-     * @param ResponseInterface $response
-     * @return static
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return \DigipolisGent\API\Client\Exception\InvalidResponse
      */
-    public static function fromResponse(ResponseInterface $response)
+    public static function fromResponse(ResponseInterface $response): InvalidResponse
     {
-        $body = (string)$response->getBody();
+        $body = (string) $response->getBody();
         $data = json_decode($body, true);
         $statusCode = $response->getStatusCode();
 
         return new static(
             sprintf(
-                'Response with status code %s was unexpected : \'%s\'',
+                'Response with status code %s was unexpected : "%s".',
                 $statusCode,
                 $body
             ),
@@ -52,9 +54,11 @@ class InvalidResponse extends Exception
     }
 
     /**
+     * Get the data that was stored into the exception.
+     *
      * @return array
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }

--- a/src/Client/Exception/Request.php
+++ b/src/Client/Exception/Request.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
 
 /**
- * Client Request exception.
- *
- * @package DigipolisGent\API\Client\Exception
+ * Exception related to a request.
  */
-class Request extends \Exception
+class Request extends Exception
 {
 
 }

--- a/src/Client/Exception/Server.php
+++ b/src/Client/Exception/Server.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
 
 /**
- * Client Server exception.
- *
- * @package DigipolisGent\API\Client\Exception
+ * Exception related to a server.
  */
-class Server extends \Exception
+class Server extends Exception
 {
 
 }

--- a/src/Client/Exception/Transport.php
+++ b/src/Client/Exception/Transport.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Exception;
 
 /**
- * Client Transport exception.
- *
- * @package DigipolisGent\API\Client\Exception
+ * Exception related to transport.
  */
-class Transport extends \Exception
+class Transport extends Exception
 {
 
 }

--- a/src/Client/Handler/HandlerInterface.php
+++ b/src/Client/Handler/HandlerInterface.php
@@ -1,30 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Handler;
 
 use DigipolisGent\API\Client\Response\ResponseInterface;
 use Psr\Http\Message as Psr;
 
 /**
- * Handlers transform PSR7-Response object to GentServices Response objects
- *
- * @package DigipolisGent\API\Client\Handler
+ * Handlers transform PSR7-Response object to Api Client Response objects
  */
 interface HandlerInterface
 {
     /**
-     * Returns the classnames of the request this handler handles
-     *      eg: [AuthRequest::class]
+     * Returns the Request class names this handler handles.
+     *
+     * eg:
+     * <code>
+     * return [AuthRequest::class];
+     * </code>
      *
      * @return string[]
      */
-    public function handles();
+    public function handles(): array;
 
     /**
-     * Converts a Psr\Response given by the http client to the corresponding Gent\Response
+     * Converts a Psr\Response from the http client to the Api Client Response.
      *
-     * @param Psr\ResponseInterface $response
-     * @return ResponseInterface
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return \DigipolisGent\API\Client\Response\ResponseInterface
      */
-    public function toResponse(Psr\ResponseInterface $response);
+    public function toResponse(Psr\ResponseInterface $response): ResponseInterface;
 }

--- a/src/Client/Request/AbstractJsonRequest.php
+++ b/src/Client/Request/AbstractJsonRequest.php
@@ -9,9 +9,9 @@ use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Abstract request requesting HTML response.
+ * Abstract request requesting JSON response.
  */
-abstract class AbstractHtmlRequest extends Request implements RequestInterface
+abstract class AbstractJsonRequest extends Request implements RequestInterface
 {
     /**
      * Constructor.
@@ -24,7 +24,7 @@ abstract class AbstractHtmlRequest extends Request implements RequestInterface
         parent::__construct(
             MethodType::GET,
             $uri->getUri(),
-            ['Accept' => AcceptType::HTML]
+            ['Accept' => AcceptType::JSON]
         );
     }
 }

--- a/src/Client/Request/AbstractXmlRequest.php
+++ b/src/Client/Request/AbstractXmlRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Request;
 
 use DigipolisGent\API\Client\Uri\UriInterface;
@@ -7,16 +9,14 @@ use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Abstract request requesting JSON response.
- *
- * @package DigipolisGent\API\Client\Request
+ * Abstract request requesting XML response.
  */
-abstract class AbstractRequest extends Request implements RequestInterface
+abstract class AbstractXmlRequest extends Request implements RequestInterface
 {
     /**
      * Constructor.
      *
-     * @param UriInterface $uri
+     * @param \DigipolisGent\API\Client\Uri\UriInterface $uri
      *   The URI for the request object.
      */
     public function __construct(UriInterface $uri)
@@ -24,7 +24,7 @@ abstract class AbstractRequest extends Request implements RequestInterface
         parent::__construct(
             MethodType::GET,
             $uri->getUri(),
-            ['Accept' => AcceptType::JSON]
+            ['Accept' => AcceptType::XML]
         );
     }
 }

--- a/src/Client/Request/AcceptType.php
+++ b/src/Client/Request/AcceptType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Request;
 
 /**
@@ -8,13 +10,6 @@ namespace DigipolisGent\API\Client\Request;
 class AcceptType
 {
     /**
-     * JSON format.
-     *
-     * @var string
-     */
-    const JSON = 'application/json';
-
-    /**
      * HTML format.
      *
      * @var string
@@ -22,9 +17,23 @@ class AcceptType
     const HTML = 'text/html';
 
     /**
+     * JSON format.
+     *
+     * @var string
+     */
+    const JSON = 'application/json';
+
+    /**
      * TEXT format.
      *
      * @var string
      */
     const TEXT = 'text/plain';
+
+    /**
+     * XML format.
+     *
+     * @var string
+     */
+    const XML = 'application/xml';
 }

--- a/src/Client/Request/MethodType.php
+++ b/src/Client/Request/MethodType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Request;
 
 /**

--- a/src/Client/Response/ResponseInterface.php
+++ b/src/Client/Response/ResponseInterface.php
@@ -1,14 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Response;
 
 /**
- * Interface Response
- *
- * Defines the GentServices response
- *
- * @package DigipolisGent\API\Client\Response
+ * Interface for a response as returned by the Handler.
  */
 interface ResponseInterface
 {
+
 }

--- a/src/Client/Uri/Uri.php
+++ b/src/Client/Uri/Uri.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Uri;
 
 /**
- * Abstract implementation of the URI.
- *
- * @package DigipolisGent\API\Client\Uri
+ * Request URI to be used to communicate with the server endpoint.
  */
 class Uri implements UriInterface
 {
@@ -21,7 +21,7 @@ class Uri implements UriInterface
      *
      * @param string $uri
      */
-    public function __construct($uri)
+    public function __construct(string $uri)
     {
         $this->uri = $uri;
     }
@@ -32,7 +32,7 @@ class Uri implements UriInterface
      * @return string
      *   The URI string.
      */
-    public function getUri()
+    public function getUri(): string
     {
         return $this->uri;
     }

--- a/src/Client/Uri/UriInterface.php
+++ b/src/Client/Uri/UriInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Client\Uri;
 
 /**
  * Interface to describe the request URI.
- *
- * @package DigipolisGent\API\Client\Uri
  */
 interface UriInterface
 {
@@ -15,5 +15,5 @@ interface UriInterface
      * @return string
      *   The URI string.
      */
-    public function getUri();
+    public function getUri(): string;
 }

--- a/src/Logger/LogInterface.php
+++ b/src/Logger/LogInterface.php
@@ -1,18 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Logger;
 
 /**
- * Interface LogInterface.
- *
- * @package DigipolisGent\API\Logger
+ * Log item interface.
  */
 interface LogInterface
 {
     /**
-     * A log should be able to be converted to a string
+     * Cast the log item to a string.
      *
      * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/Logger/LoggableInterface.php
+++ b/src/Logger/LoggableInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Logger;
 
 /**
- * Interface LoggableInterface.
- *
- * @package DigipolisGent\API\Logger
+ * Allows loggers to be added to an object.
  */
 interface LoggableInterface
 {
@@ -14,5 +14,5 @@ interface LoggableInterface
      *
      * @param LoggerInterface $logger
      */
-    public function addLogger(LoggerInterface $logger);
+    public function addLogger(LoggerInterface $logger): void;
 }

--- a/src/Logger/LoggableTrait.php
+++ b/src/Logger/LoggableTrait.php
@@ -1,29 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Logger;
 
 /**
- * Class LoggableTrait.
- *
  * Use this trait to add loggers to an object.
- *
- * @package DigipolisGent\API\Logger
  */
 trait LoggableTrait
 {
     /**
      * Array of loggers.
      *
-     * @var LoggerInterface[]
+     * @var \DigipolisGent\API\Logger\LoggerInterface[]
      */
-    protected $loggers = array();
+    protected $loggers = [];
 
     /**
      * Add a logger to an object.
      *
-     * @param LoggerInterface $logger
+     * @param \DigipolisGent\API\Logger\LoggerInterface $logger
      */
-    public function addLogger(LoggerInterface $logger)
+    public function addLogger(LoggerInterface $logger): void
     {
         $this->loggers[] = $logger;
     }
@@ -33,7 +31,7 @@ trait LoggableTrait
      *
      * @param LogInterface $log
      */
-    protected function log(LogInterface $log)
+    protected function log(LogInterface $log): void
     {
         foreach ($this->loggers as $logger) {
             $logger->log($log);

--- a/src/Logger/LoggerInterface.php
+++ b/src/Logger/LoggerInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Logger;
 
 /**
- * Interface LoggerInterface.
- *
- * @package DigipolisGent\API\Logger
+ * Logger interface.
  */
 interface LoggerInterface
 {
@@ -15,5 +15,5 @@ interface LoggerInterface
      * @param LogInterface $log
      *   The log item to log.
      */
-    public function log(LogInterface $log);
+    public function log(LogInterface $log): void;
 }

--- a/src/Logger/RequestLog.php
+++ b/src/Logger/RequestLog.php
@@ -1,20 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Logger;
 
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * Create a log item from a PSR HTTP Request.
+ */
 class RequestLog implements LogInterface
 {
     /**
-     * @var RequestInterface
+     * The request this log item is about.
+     *
+     * @var \Psr\Http\Message\RequestInterface
      */
     protected $request;
 
     /**
-     * RequestLog constructor.
+     * Create new log item from given request.
      *
-     * @param RequestInterface $request
+     * @param \Psr\Http\Message\RequestInterface $request
      */
     public function __construct(RequestInterface $request)
     {
@@ -24,14 +31,14 @@ class RequestLog implements LogInterface
     /**
      * @inheritDoc
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return (string)sprintf(
+        return (string) sprintf(
             "Request \n Method %s \n Headers %s \n URI %s \n Body %s \n \n",
             $this->request->getMethod(),
-            (string)json_encode($this->request->getHeaders()),
-            (string)$this->request->getUri(),
-            (string)$this->request->getBody()
+            (string) json_encode($this->request->getHeaders()),
+            (string) $this->request->getUri(),
+            (string) json_encode($this->request->getBody())
         );
     }
 }

--- a/src/Logger/ResponseLog.php
+++ b/src/Logger/ResponseLog.php
@@ -1,19 +1,27 @@
 <?php
+
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Logger;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Create a log item from a PSR HTTP Response.
+ */
 class ResponseLog implements LogInterface
 {
     /**
-     * @var ResponseInterface
+     * The response this log item is about.
+     *
+     * @var \Psr\Http\Message\ResponseInterface
      */
     protected $response;
 
     /**
-     * ResponseLog constructor.
+     * Create the log item from given response.
      *
-     * @param ResponseInterface $response
+     * @param \Psr\Http\Message\ResponseInterface $response
      */
     public function __construct(ResponseInterface $response)
     {
@@ -23,13 +31,13 @@ class ResponseLog implements LogInterface
     /**
      * @inheritDoc
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)sprintf(
             "Response \n Status %s \n Headers %s \n Body %s \n \n",
             $this->response->getStatusCode(),
-            (string)json_encode($this->response->getHeaders()),
-            (string)json_encode($this->response->getBody())
+            (string) json_encode($this->response->getHeaders()),
+            (string) json_encode($this->response->getBody())
         );
     }
 }

--- a/src/Service/Exception/ServiceException.php
+++ b/src/Service/Exception/ServiceException.php
@@ -1,7 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Service\Exception;
 
-class ServiceException extends \Exception
+use Exception;
+
+/**
+ * Base class for service exceptions.
+ */
+class ServiceException extends Exception
 {
+
 }

--- a/src/Service/Exception/UnexpectedResponse.php
+++ b/src/Service/Exception/UnexpectedResponse.php
@@ -1,18 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Service\Exception;
 
+/**
+ * Exception when the response object was not of the correct type.
+ */
 class UnexpectedResponse extends ServiceException
 {
     /**
      * Generates exception with certain message
      *
      * @param string $actual
+     *   The actual class name.
      * @param string $expected
-     * @return static
+     *   The expected class name.
+     *
+     * @return \DigipolisGent\API\Service\Exception\UnexpectedResponse
      */
-    public static function fromClass($actual, $expected)
+    public static function fromClass($actual, $expected): UnexpectedResponse
     {
-        return new static(sprintf('Got instance of %s expected %s response', $actual, $expected));
+        $message = sprintf(
+            'Got instance of %s expected %s response',
+            $actual,
+            $expected
+        );
+
+        return new static($message, 500);
     }
 }

--- a/src/Service/ServiceAbstract.php
+++ b/src/Service/ServiceAbstract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Service;
 
 use DigipolisGent\API\Cache\CacheableInterface;
@@ -9,9 +11,7 @@ use DigipolisGent\API\Logger\LoggableInterface;
 use DigipolisGent\API\Logger\LoggableTrait;
 
 /**
- * Class ServiceAbstract.
- *
- * @package DigipolisGent\API\Service
+ * Abstract service containing the client to access the backend.
  */
 abstract class ServiceAbstract implements ServiceInterface, LoggableInterface, CacheableInterface
 {
@@ -19,17 +19,25 @@ abstract class ServiceAbstract implements ServiceInterface, LoggableInterface, C
     use CacheableTrait;
 
     /**
-     * @var ClientInterface
+     * @var \DigipolisGent\API\Client\ClientInterface
      */
-    protected $client;
+    private $client;
 
     /**
-     * @param ClientInterface $client
-     *
-     * @codeCoverageIgnore
+     * @param \DigipolisGent\API\Client\ClientInterface $client
      */
     public function __construct(ClientInterface $client)
     {
         $this->client = $client;
+    }
+
+    /**
+     * Get the client.
+     *
+     * @return \DigipolisGent\API\Client\ClientInterface
+     */
+    protected function client(): ClientInterface
+    {
+        return $this->client;
     }
 }

--- a/src/Service/ServiceInterface.php
+++ b/src/Service/ServiceInterface.php
@@ -1,20 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Service;
 
 use DigipolisGent\API\Client\ClientInterface;
 
 /**
- * Interface ServiceInterface.
- *
- * @package DigipolisGent\API\Service
+ * Interface for services.
  */
 interface ServiceInterface
 {
     /**
      * ServiceInterface constructor.
      *
-     * @param ClientInterface $client
+     * @param \DigipolisGent\API\Client\ClientInterface $client
      */
     public function __construct(ClientInterface $client);
 }

--- a/tests/Cache/CacheableTraitTest.php
+++ b/tests/Cache/CacheableTraitTest.php
@@ -33,7 +33,7 @@ class CacheableTraitTest extends TestCase
      *
      * @test
      */
-    public function cacheDeletetWithoutCache(): void
+    public function cacheDeletedWithoutCache(): void
     {
         $key = uniqid();
 
@@ -88,7 +88,7 @@ class CacheableTraitTest extends TestCase
      *
      * @test
      */
-    public function cacheDeletetWithCache(): void
+    public function cacheDeletedWithCache(): void
     {
         $key = uniqid();
 

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -37,11 +37,6 @@ class ClientTest extends TestCase
     protected $configuration;
 
     /**
-     * @var \DigipolisGent\API\Client\AbstractClient
-     */
-    protected $client;
-
-    /**
      * @var \Psr\Http\Message\RequestInterface
      */
     protected $request;

--- a/tests/Client/Configuration/ConfigurationTest.php
+++ b/tests/Client/Configuration/ConfigurationTest.php
@@ -43,11 +43,11 @@ class ConfigurationTest extends TestCase
      */
     public function constructorWithOptions(): void
     {
-        $options = array(
+        $options = [
             'version' => 2,
             'timeout' => 10,
             'foo' => 'bar',
-        );
+        ];
         $configuration = new Configuration(
             'https://foo.com',
             $options

--- a/tests/Client/Configuration/ConfigurationTest.php
+++ b/tests/Client/Configuration/ConfigurationTest.php
@@ -1,26 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Client\Configuration;
 
 use DigipolisGent\API\Client\Configuration\Configuration;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \DigipolisGent\API\Client\Configuration\Configuration
+ */
 class ConfigurationTest extends TestCase
 {
-
     /**
-     * Test constructor without options.
+     * Configuration can be created without options.
+     *
+     * @test
      */
-    public function testConstructorWithoutOptions()
+    public function configurationCanBeCreatedWithoutOptions(): void
     {
         $uri = 'https://test-endpoint.gent';
         $configuration = new Configuration($uri);
 
         $this->assertEquals($uri, $configuration->getUri(), 'Uri is set.');
 
-        // Default options.
-        $this->assertEquals(
-            1,
+        $this->assertSame(
+            '1',
             $configuration->getVersion(),
             'Default version is "1".'
         );
@@ -32,9 +37,11 @@ class ConfigurationTest extends TestCase
     }
 
     /**
-     * Test constructor with options.
+     * Configuration can be created with options.
+     *
+     * @test
      */
-    public function testConstructorWithOptions()
+    public function constructorWithOptions(): void
     {
         $options = array(
             'version' => 2,
@@ -46,13 +53,12 @@ class ConfigurationTest extends TestCase
             $options
         );
 
-        // Custom options.
-        $this->assertEquals(
-            $options['version'],
+        $this->assertSame(
+            (string) $options['version'],
             $configuration->getVersion(),
             'Version is set to custom value.'
         );
-        $this->assertEquals(
+        $this->assertSame(
             $options['timeout'],
             $configuration->getTimeout(),
             'Timeout is set to custom value.'

--- a/tests/Client/Exception/HandlerNotFoundTest.php
+++ b/tests/Client/Exception/HandlerNotFoundTest.php
@@ -1,19 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Client\Exception;
 
 use DigipolisGent\API\Client\Exception\HandlerNotFound;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * @covers \DigipolisGent\API\Client\Exception\HandlerNotFound
+ */
 class HandlerNotFoundTest extends TestCase
 {
-
-    public function testFromRequest()
+    /**
+     * Exception can be created from a given request.
+     *
+     * @test
+     */
+    public function exceptionCanBeCreatedFromRequest(): void
     {
-        $request = $this->getMockBuilder(RequestInterface::class)->getMock();
-        $message = sprintf('No handler was registered for %s', get_class($request));
+        $request = $this->prophesize(RequestInterface::class)->reveal();
+        $expectedMessage = sprintf(
+            'No handler was registered for %s',
+            get_class($request)
+        );
+
         $exception = HandlerNotFound::fromRequest($request);
-        $this->assertEquals($message, $exception->getMessage());
+        $this->assertEquals($expectedMessage, $exception->getMessage());
     }
 }

--- a/tests/Client/Exception/InvalidResponseTest.php
+++ b/tests/Client/Exception/InvalidResponseTest.php
@@ -1,25 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Client\Exception;
 
 use DigipolisGent\API\Client\Exception\InvalidResponse;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @covers \DigipolisGent\API\Client\Exception\InvalidResponse
+ */
 class InvalidResponseTest extends TestCase
 {
-
-    public function testFromResponse()
+    /**
+     * Exception can be created from response.
+     *
+     * @test
+     */
+    public function exceptionCanBeCreatedFromResponse()
     {
-        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $data = ['value' => uniqid()];
         $jsonData = json_encode($data);
         $statusCode = random_int(200, 500);
-        $response->expects($this->once())->method('getBody')->willReturn($jsonData);
-        $response->expects($this->once())->method('getStatusCode')->willReturn($statusCode);
-        $exception = InvalidResponse::fromResponse($response);
-        $this->assertContains($jsonData, $exception->getMessage());
-        $this->assertContains((string) $statusCode, $exception->getMessage());
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()->willReturn($jsonData);
+        $response->getStatusCode()->willReturn($statusCode);
+
+        $exception = InvalidResponse::fromResponse($response->reveal());
+
+        $this->assertStringContainsString($jsonData, $exception->getMessage());
+        $this->assertStringContainsString((string) $statusCode, $exception->getMessage());
         $this->assertEquals($data, $exception->getData());
     }
 }

--- a/tests/Client/Request/AbstractHtmlRequestTest.php
+++ b/tests/Client/Request/AbstractHtmlRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gent\Tests\API\Client\Request;
+
+use DigipolisGent\API\Client\Request\AbstractHtmlRequest;
+use DigipolisGent\API\Client\Request\AcceptType;
+use DigipolisGent\API\Client\Request\MethodType;
+use DigipolisGent\API\Client\Uri\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DigipolisGent\API\Client\Request\AbstractHtmlRequest
+ */
+class AbstractHtmlRequestTest extends TestCase
+{
+    /**
+     * Request has default method and accept header.
+     *
+     * @test
+     */
+    public function requestHasProperMethodAndHeaders(): void
+    {
+        $request = $this->getMockForAbstractClass(
+            AbstractHtmlRequest::class,
+            [new Uri('/test')]
+        );
+
+        $this->assertEquals(MethodType::GET, $request->getMethod());
+        $this->assertEquals([AcceptType::HTML], $request->getHeader('Accept'));
+    }
+}

--- a/tests/Client/Request/AbstractJsonRequestTest.php
+++ b/tests/Client/Request/AbstractJsonRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gent\Tests\API\Client\Request;
+
+use DigipolisGent\API\Client\Request\AbstractJsonRequest;
+use DigipolisGent\API\Client\Request\AcceptType;
+use DigipolisGent\API\Client\Request\MethodType;
+use DigipolisGent\API\Client\Uri\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DigipolisGent\API\Client\Request\AbstractJsonRequest
+ */
+class AbstractJsonRequestTest extends TestCase
+{
+    /**
+     * Request has default method and accept header.
+     *
+     * @test
+     */
+    public function requestHasProperMethodAndHeaders(): void
+    {
+        $request = $this->getMockForAbstractClass(
+            AbstractJsonRequest::class,
+            [new Uri('/test')]
+        );
+
+        $this->assertEquals(MethodType::GET, $request->getMethod());
+        $this->assertEquals([AcceptType::JSON], $request->getHeader('Accept'));
+    }
+}

--- a/tests/Client/Request/AbstractXmlRequestTest.php
+++ b/tests/Client/Request/AbstractXmlRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gent\Tests\API\Client\Request;
+
+use DigipolisGent\API\Client\Request\AbstractXmlRequest;
+use DigipolisGent\API\Client\Request\AcceptType;
+use DigipolisGent\API\Client\Request\MethodType;
+use DigipolisGent\API\Client\Uri\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DigipolisGent\API\Client\Request\AbstractXmlRequest
+ */
+class AbstractXmlRequestTest extends TestCase
+{
+    /**
+     * Request has default method and accept header.
+     *
+     * @test
+     */
+    public function requestHasProperMethodAndHeaders(): void
+    {
+        $request = $this->getMockForAbstractClass(
+            AbstractXmlRequest::class,
+            [new Uri('/test')]
+        );
+
+        $this->assertEquals(MethodType::GET, $request->getMethod());
+        $this->assertEquals([AcceptType::XML], $request->getHeader('Accept'));
+    }
+}

--- a/tests/Client/Uri/UriTest.php
+++ b/tests/Client/Uri/UriTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gent\Tests\API\Client\Uri;
+
+use DigipolisGent\API\Client\Uri\Uri;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DigipolisGent\API\Client\Uri\Uri
+ */
+class UriTest extends TestCase
+{
+    /**
+     * URI can be created from its URI path.
+     *
+     * @test
+     */
+    public function uriCanBeCreatedFromItsPath(): void
+    {
+        $uri = new Uri('/test');
+
+        $this->assertEquals('/test', $uri->getUri());
+    }
+}

--- a/tests/Logger/LoggableTraitTest.php
+++ b/tests/Logger/LoggableTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Logger;
 
 use DigipolisGent\API\Logger\LoggableTrait;
@@ -7,29 +9,26 @@ use DigipolisGent\API\Logger\LoggerInterface;
 use DigipolisGent\API\Logger\LogInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \DigipolisGent\API\Logger\LoggableTrait
+ */
 class LoggableTraitTest extends TestCase
 {
 
     use LoggableTrait;
 
     /**
-     * @var LogInterface
+     * Log item is passed to the loggers.
+     *
+     * @test
      */
-    protected $log;
-
-    protected function setUp(): void
+    public function logItemIsPassedToLoggers(): void
     {
-        parent::setUp();
-        $this->log = $this->getMockBuilder(LogInterface::class)->getMock();
-        for ($i = 0; $i <= random_int(2, 5); $i++) {
-            $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-            $logger->expects($this->atLeastOnce())->method('log')->with($this->log);
-            $this->addLogger($logger);
-        }
-    }
+        $logItem = $this->prophesize(LogInterface::class)->reveal();
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger->log($logItem)->shouldBeCalled();
 
-    public function testLog()
-    {
-        $this->assertNull($this->log($this->log));
+        $this->addLogger($logger->reveal());
+        $this->log($logItem);
     }
 }

--- a/tests/Logger/RequestLogTest.php
+++ b/tests/Logger/RequestLogTest.php
@@ -1,30 +1,42 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Logger;
 
 use DigipolisGent\API\Logger\RequestLog;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * @covers \DigipolisGent\API\Logger\RequestLog
+ */
 class RequestLogTest extends TestCase
 {
-
-    public function testToString()
+    /**
+     * Cast to string contains all request details.
+     *
+     * @test
+     */
+    public function castToStringHasAllDetails(): void
     {
-        $request = $this->getMockBuilder(RequestInterface::class)->getMock();
-        $method = uniqid();
-        $headers = uniqid();
-        $uri = uniqid();
-        $body = uniqid();
-        // Log should contain method, headers, uri and body.
-        $request->expects($this->any())->method('getMethod')->willReturn($method);
-        $request->expects($this->any())->method('getHeaders')->willReturn($headers);
-        $request->expects($this->any())->method('getUri')->willReturn($uri);
-        $request->expects($this->any())->method('getBody')->willReturn($body);
-        $log = (string)(new RequestLog($request));
-        $this->assertContains($method, $log);
-        $this->assertContains($headers, $log);
-        $this->assertContains($uri, $log);
-        $this->assertContains($body, $log);
+        $request = $this->prophesize(RequestInterface::class);
+        $request->getMethod()->willReturn('GET');
+        $request->getHeaders()->willReturn(['test' => 'foo']);
+        $request->getUri()->willReturn('/uriTest');
+        $request->getBody()->willReturn('bodyTest');
+
+        $logItem = new RequestLog($request->reveal());
+
+        $expected = <<<EOT
+Request 
+ Method GET 
+ Headers {"test":"foo"} 
+ URI /uriTest 
+ Body "bodyTest" 
+ 
+
+EOT;
+        $this->assertEquals($expected, (string) $logItem);
     }
 }

--- a/tests/Logger/ResponseLogTest.php
+++ b/tests/Logger/ResponseLogTest.php
@@ -1,27 +1,40 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Logger;
 
 use DigipolisGent\API\Logger\ResponseLog;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @covers \DigipolisGent\API\Logger\ResponseLog
+ */
 class ResponseLogTest extends TestCase
 {
-
-    public function testToString()
+    /**
+     * Cast to string contains all response details.
+     *
+     * @test
+     */
+    public function castToStringHasAllDetails(): void
     {
-        $request = $this->getMockBuilder(ResponseInterface::class)->getMock();
-        $statusCode = uniqid();
-        $headers = uniqid();
-        $body = uniqid();
-        // Log should contain status code, headers and body.
-        $request->expects($this->any())->method('getStatusCode')->willReturn($statusCode);
-        $request->expects($this->any())->method('getHeaders')->willReturn($headers);
-        $request->expects($this->any())->method('getBody')->willReturn($body);
-        $log = (string)(new ResponseLog($request));
-        $this->assertContains($statusCode, $log);
-        $this->assertContains($headers, $log);
-        $this->assertContains($body, $log);
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(400);
+        $response->getHeaders()->willReturn(['test' => 'foo']);
+        $response->getBody()->willReturn('bodyTest');
+
+        $logItem = new ResponseLog($response->reveal());
+
+        $expected = <<<EOT
+Response 
+ Status 400 
+ Headers {"test":"foo"} 
+ Body "bodyTest" 
+ 
+
+EOT;
+        $this->assertEquals($expected, (string) $logItem);
     }
 }

--- a/tests/Service/Exception/UnexpectedResponseTest.php
+++ b/tests/Service/Exception/UnexpectedResponseTest.php
@@ -1,20 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DigipolisGent\API\Tests\Service\Exception;
 
 use DigipolisGent\API\Service\Exception\UnexpectedResponse;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \DigipolisGent\API\Service\Exception\UnexpectedResponse
+ */
 class UnexpectedResponseTest extends TestCase
 {
-
-    public function testFromClass()
+    /**
+     * Exception can be created from the actual and expected class name.
+     *
+     * @test
+     */
+    public function exceptionCanBeCreatedFromClassNames(): void
     {
-        $actual = uniqid();
-        $expected = uniqid();
-        $exception = UnexpectedResponse::fromClass($actual, $expected);
-        // Message should contain both classnames.
-        $this->assertContains($actual, $exception->getMessage());
-        $this->assertContains($expected, $exception->getMessage());
+        $exception = UnexpectedResponse::fromClass('Actual', 'Expected');
+        $this->assertEquals(
+            'Got instance of Actual expected Expected response',
+            $exception->getMessage()
+        );
+        $this->assertSame(500, $exception->getCode());
     }
 }

--- a/tests/Service/ServiceAbstractTest.php
+++ b/tests/Service/ServiceAbstractTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gent\Tests\API\Service;
+
+use DigipolisGent\API\Client\ClientInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DigipolisGent\API\Service\ServiceAbstract
+ */
+class ServiceAbstractTest extends TestCase
+{
+    /**
+     * Service can be created with client.
+     *
+     * @test
+     */
+    public function serviceCanBeCreatedFromClient(): void
+    {
+        $client = $this->prophesize(ClientInterface::class)->reveal();
+        $service = new TestService($client);
+
+        $this->assertSame($client, $service->getClient());
+    }
+}

--- a/tests/Service/TestService.php
+++ b/tests/Service/TestService.php
@@ -6,7 +6,6 @@ namespace Gent\Tests\API\Service;
 
 use DigipolisGent\API\Client\ClientInterface;
 use DigipolisGent\API\Service\ServiceAbstract;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Test class to validate the ServiceAbstract.

--- a/tests/Service/TestService.php
+++ b/tests/Service/TestService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gent\Tests\API\Service;
+
+use DigipolisGent\API\Client\ClientInterface;
+use DigipolisGent\API\Service\ServiceAbstract;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class to validate the ServiceAbstract.
+ *
+ * @codeCoverageIgnore
+ */
+class TestService extends ServiceAbstract
+{
+    /**
+     * Method only for testing purposes.
+     *
+     * @return \DigipolisGent\API\Client\ClientInterface
+     */
+    public function getClient(): ClientInterface
+    {
+        return $this->client();
+    }
+}


### PR DESCRIPTION
This PR will result in a 2.0.0 release.

## Added

* Added AbstractXmlRequest class.

## Changed

* Made the code strict.
* Renamed the AbstractRequest class to AbstractJsonRequest.
* The client in ServiceAbstract is now only accessible in extending
  classes trough protected method ServiceAbstract::client().
  
## Removed

* Removed chaining ClientInterface::addHandler() method calls.