### PR TITLE
Add getHandlers to ClientInterface

### DIFF
--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -126,4 +126,14 @@ abstract class AbstractClient implements ClientInterface, LoggableInterface
             $this->handlers[$requestType] = $handler;
         }
     }
+
+    /**
+     * Get handlers.
+     *
+     * @return Handler\HandlerInterface[]
+     */
+    public function getHandlers()
+    {
+        return $this->handlers;
+    }
 }

--- a/src/Client/ClientInterface.php
+++ b/src/Client/ClientInterface.php
@@ -25,9 +25,16 @@ interface ClientInterface
     public function send(RequestInterface $request): ResponseInterface;
 
     /**
-     * Adds a Handler to the Client
+     * Adds a Handler to the Client.
      *
      * @param \DigipolisGent\API\Client\Handler\HandlerInterface $handler
      */
     public function addHandler(HandlerInterface $handler): void;
+
+    /**
+     * Get handlers.
+     *
+     * @return Handler\HandlerInterface[]
+     */
+    public function getHandlers();
 }


### PR DESCRIPTION
At the moment there are a lot of phpunit test that try to test that a factory method adds a given set of handlers to the ClientInterface that it accepts as an argument.
Because the client doesn't have a getHandlers() method, the tests use mocks with a spy to check the amount of invocations but also the specific invocations ...

Since phpunit 8.4 `PHPUnit\Framework\MockObject\Matcher\InvokedRecorder::getInvocations()` is no longer public. See https://github.com/sebastianbergmann/phpunit/issues/3888

So without a getHandler() operation on the ClientInterface it's no longer possible to test if all handlers have been added.

That said, I don't think that testing for the handlers in the factory method is the way to go as it is testing the implementation and not the functionality (someone may some day refactor the handler or swap another handler, this will now break tests while the functionality may still be ok).